### PR TITLE
Migrate from UA to GA4 tag for GA

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,17 +1,17 @@
 <!doctype html>
 <html>
   <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-94XS2SB0TX"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-94XS2SB0TX');
+    </script>
+
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-112765193-1"></script>
-    <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-112765193-1');
-    </script>
     
     <meta name="keywords" content="Montgomery's ladder, Montgomery ladder, Side-channel attack, ECDSA" />
     <meta name="DC.title" content="Montgomery's ladder" />


### PR DESCRIPTION
For site analytics. The old UA tag stopped working on July 1, 2023.